### PR TITLE
Add set_symlink_file_times for better symlink support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,8 @@ Platform-agnostic accessors of timestamps in File metadata
 [dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.2"
+
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,5 +301,30 @@ mod tests {
         let metadata = fs::metadata(&path).unwrap();
         let mtime = FileTime::from_last_modification_time(&metadata);
         assert_eq!(mtime, new_mtime);
+
+        let spath = td.path().join("bar.txt");
+        make_symlink(&path, &spath).unwrap();
+        let metadata = fs::symlink_metadata(&spath).unwrap();
+        let smtime = FileTime::from_last_modification_time(&metadata);
+
+        set_file_times(&spath, atime, mtime).unwrap();
+
+        let metadata = fs::metadata(&path).unwrap();
+        let cur_mtime = FileTime::from_last_modification_time(&metadata);
+        assert_eq!(mtime, cur_mtime);
+
+        let metadata = fs::symlink_metadata(&spath).unwrap();
+        let cur_mtime = FileTime::from_last_modification_time(&metadata);
+        assert_eq!(smtime, cur_mtime);
+
+        set_file_times(&spath, atime, new_mtime).unwrap();
+
+        let metadata = fs::metadata(&path).unwrap();
+        let mtime = FileTime::from_last_modification_time(&metadata);
+        assert_eq!(mtime, new_mtime);
+
+        let metadata = fs::symlink_metadata(&spath).unwrap();
+        let mtime = FileTime::from_last_modification_time(&metadata);
+        assert_eq!(mtime, smtime);
     }
 }


### PR DESCRIPTION
This adds the method set_symlink_file_times that doesn't follow
symlinks and instead sets the time of the symlink itself.

Because implementations of set_file_times and set_symlink_file_times
are so similar for both windows and unix I have also refactor the code
be adding set_file_times_w for windows and set_file_times_u for unix
that contains the shared code for the two functions.