### PR TITLE
bump version to 0.1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "filetime"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.1.12"
+version = "0.1.13"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["timestamp", "mtime"]


### PR DESCRIPTION
it will permit rustc to pick a filetime version with `utimensat` changes for netbsd, openbsd, and solaris