### PR TITLE
Add function to create FileTime from SystemTime

### DIFF
--- a/src/redox.rs
+++ b/src/redox.rs
@@ -40,14 +40,14 @@ fn set_file_times_redox(fd: usize, atime: FileTime, mtime: FileTime) -> io::Resu
 
 pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {
     FileTime {
-        seconds: meta.mtime() as u64,
+        seconds: meta.mtime(),
         nanos: meta.mtime_nsec() as u32,
     }
 }
 
 pub fn from_last_access_time(meta: &fs::Metadata) -> FileTime {
     FileTime {
-        seconds: meta.atime() as u64,
+        seconds: meta.atime(),
         nanos: meta.atime_nsec() as u32,
     }
 }

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -24,7 +24,7 @@ fn set_file_times_redox(fd: usize, atime: FileTime, mtime: FileTime) -> io::Resu
 
     fn to_timespec(ft: &FileTime) -> TimeSpec {
         TimeSpec {
-            tv_sec: ft.seconds() as i64,
+            tv_sec: ft.seconds(),
             tv_nsec: ft.nanoseconds() as i32
         }
     }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -79,14 +79,14 @@ fn utimensat(p: &Path,
 
 pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {
     FileTime {
-        seconds: meta.mtime() as u64,
+        seconds: meta.mtime(),
         nanos: meta.mtime_nsec() as u32,
     }
 }
 
 pub fn from_last_access_time(meta: &fs::Metadata) -> FileTime {
     FileTime {
-        seconds: meta.atime() as u64,
+        seconds: meta.atime(),
         nanos: meta.atime_nsec() as u32,
     }
 }
@@ -101,7 +101,7 @@ pub fn from_creation_time(meta: &fs::Metadata) -> Option<FileTime> {
                     use std::os::$i::fs::MetadataExt;
                 )*
                 Some(FileTime {
-                    seconds: meta.st_birthtime() as u64,
+                    seconds: meta.st_birthtime(),
                     nanos: meta.st_birthtime_nsec() as u32,
                 })
             }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -57,7 +57,7 @@ pub fn set_file_times_w(p: &Path,
 
     fn to_filetime(ft: &FileTime) -> FILETIME {
         let intervals = ft.seconds() * (1_000_000_000 / 100) +
-                        ((ft.nanoseconds() as u64) / 100);
+                        ((ft.nanoseconds() as i64) / 100);
         FILETIME {
             dwLowDateTime: intervals as DWORD,
             dwHighDateTime: (intervals >> 32) as DWORD,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -81,7 +81,7 @@ fn from_intervals(ticks: u64) -> FileTime {
     // Windows write times are in 100ns intervals, so do a little math to
     // get it into the right representation.
     FileTime {
-        seconds: ticks / (1_000_000_000 / 100),
+        seconds: (ticks / (1_000_000_000 / 100)) as i64,
         nanos: ((ticks % (1_000_000_000 / 100)) * 100) as u32,
     }
 }


### PR DESCRIPTION
My primary motivation for this is to be able to handle pre-Unix-epoch timestamps, and having a `from_system_time()` is also useful as I'm currently converting to and from Unix epoch to get from SystemTime to FileTime. 

As was suggested in #6, I've avoided breaking existing API functions by casting between signed and unsigned integers, though this means that nonsense will be returned by the `seconds()`, `seconds_relative_to_1970()` and `nanoseconds()` functions on Unixy systems when FileTime is pre-Unix-epoch. I think breakage would be better as it is a 0.1.x library and to/from Unix timestamp functions should really be able to handle the case where they're pre-Unix-epoch, but I thought I'd make minimal changes and see what you thought.

I'm not sure if the handling of mtime_nsec() values is correct, the docs don't suggest it's a fractional second value, but I've preserved the existing behaviour, modulo unsigned -> signed cast.

I've tested the changes on Windows and Linux, I'm not sure about other OSes but I tried to update them as I did for Linux.