### PR TITLE
Fix Emscripten and FreeBSD

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -18,7 +18,9 @@ cfg_if! {
     } else if #[cfg(any(target_os = "android",
                         target_os = "solaris",
                         target_os = "netbsd",
-                        target_os = "openbsd"))] {
+                        target_os = "openbsd",
+                        target_os = "freebsd",
+                        target_os = "emscripten"))] {
         mod utimensat;
         pub use self::utimensat::*;
     } else {


### PR DESCRIPTION
My primary motivation is to fix #24 
However this also fixes #29, but I didn't test it.

On emscripten `utimes` is just a wrapper on top of `utimensat`, which is why my change makes sense:
https://github.com/kripken/emscripten/blob/6e4b98636618989bcd99308391e51aa1b81f4c61/system/lib/libc/musl/src/linux/utimes.c#L9
https://github.com/kripken/emscripten/blob/6e4b98636618989bcd99308391e51aa1b81f4c61/system/lib/libc/musl/src/stat/futimesat.c#L20

However the tests don't work because:
- It looks like `flags` have to be 0, so `set_symlink_file_times` doesn't work: https://github.com/kripken/emscripten/blob/52ff847187ee30fba48d611e64b5d10e2498fe0f/src/library_syscall.js#L1260
- Emscripten doesn't seem to differentiate between last access time and last modification time. It just uses the highest of the two instead (https://github.com/kripken/emscripten/blob/2a73c5eb0efc51b5a64c725bf25949d04fb88f0c/src/library_fs.js#L976). Should I modify the tests to make them pass, or should I accept the failures?
