### PR TITLE
missing libc def for utimensat in 0.2.43, *bsd targets should use uti…

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -15,11 +15,11 @@ cfg_if! {
     if #[cfg(target_os = "linux")] {
         mod linux;
         pub use self::linux::*;
+    // netbsd, openbsd and freebsd should use utimensat, but the call is not
+    // in the latest rust libc (0.2.43). as soon as a new version is available
+    // these target_os'es should be added back in.
     } else if #[cfg(any(target_os = "android",
                         target_os = "solaris",
-                        target_os = "netbsd",
-                        target_os = "openbsd",
-                        target_os = "freebsd",
                         target_os = "emscripten"))] {
         mod utimensat;
         pub use self::utimensat::*;


### PR DESCRIPTION
so this removes the *bsd targets as the utimensat call is not in libc 0.2.43