### PR TITLE
Implement set_file_mtime and set_file_atime for Unix platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,9 @@ redox_syscall = "0.1"
 
 [dev-dependencies]
 tempdir = "0.3"
+
+[features]
+# On Unix platforms, forces the use of the `utimensat` syscall rather than the
+# older `utimes`. This will expose functions for setting only the mtime or only
+# the atime for a file, but will cause panics if `utimensat` cannot be called.
+utimensat = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,14 @@ pub fn set_symlink_file_times<P>(p: P, atime: FileTime, mtime: FileTime)
 ///
 /// Currently only supported on Unix platforms with the `utimensat` feature
 /// enabled.
-#[cfg(all(feature = "utimensat", not(any(target_os = "redox", windows))))]
+#[cfg(all(feature = "utimensat",
+          any(target_os = "linux",
+              target_os = "android",
+              target_os = "solaris",
+              target_os = "emscripten",
+              target_os = "freebsd",
+              target_os = "netbsd",
+              target_os = "openbsd")))]
 pub fn set_file_mtime<P>(p: P, mtime: FileTime)
     -> io::Result<()>
     where P: AsRef<Path>
@@ -233,7 +240,14 @@ pub fn set_file_mtime<P>(p: P, mtime: FileTime)
 ///
 /// Currently only supported on Unix platforms with the `utimensat` feature
 /// enabled.
-#[cfg(all(feature = "utimensat", not(any(target_os = "redox", windows))))]
+#[cfg(all(feature = "utimensat",
+          any(target_os = "linux",
+              target_os = "android",
+              target_os = "solaris",
+              target_os = "emscripten",
+              target_os = "freebsd",
+              target_os = "netbsd",
+              target_os = "openbsd")))]
 pub fn set_file_atime<P>(p: P, atime: FileTime)
     -> io::Result<()>
     where P: AsRef<Path>
@@ -464,7 +478,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "utimensat", not(any(target_os = "redox", windows))))]
+    #[cfg(all(feature = "utimensat",
+              any(target_os = "linux",
+                  target_os = "android",
+                  target_os = "solaris",
+                  target_os = "emscripten",
+                  target_os = "freebsd",
+                  target_os = "netbsd",
+                  target_os = "openbsd")))]
     fn set_single_time_test() {
         use super::{set_file_mtime, set_file_atime};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,10 @@ pub fn set_symlink_file_times<P>(p: P, atime: FileTime, mtime: FileTime)
 ///
 /// This function will set the `mtime` metadata field for a file on the local
 /// filesystem, returning any error encountered.
-#[cfg(not(any(target_os = "redox", windows)))]
+///
+/// Currently only supported on Unix platforms with the `utimensat` feature
+/// enabled.
+#[cfg(all(feature = "utimensat", not(any(target_os = "redox", windows))))]
 pub fn set_file_mtime<P>(p: P, mtime: FileTime)
     -> io::Result<()>
     where P: AsRef<Path>
@@ -228,8 +231,9 @@ pub fn set_file_mtime<P>(p: P, mtime: FileTime)
 /// This function will set the `atime` metadata field for a file on the local
 /// filesystem, returning any error encountered.
 ///
-/// Currently only supported for Unix systems.
-#[cfg(not(any(target_os = "redox", windows)))]
+/// Currently only supported on Unix platforms with the `utimensat` feature
+/// enabled.
+#[cfg(all(feature = "utimensat", not(any(target_os = "redox", windows))))]
 pub fn set_file_atime<P>(p: P, atime: FileTime)
     -> io::Result<()>
     where P: AsRef<Path>
@@ -460,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(target_os = "redox", windows)))]
+    #[cfg(all(feature = "utimensat", not(any(target_os = "redox", windows))))]
     fn set_single_time_test() {
         use super::{set_file_mtime, set_file_atime};
 

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -7,13 +7,25 @@ use std::path::Path;
 
 use FileTime;
 
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
+    let (atime, mtime) = match (atime, mtime) {
+        (Some(atime), Some(mtime)) => (atime, mtime),
+        (None, None) => return Ok(()),
+        _ => unimplemented!("Must set both atime and mtime on Redox"),
+    };
+
     let fd = syscall::open(p.as_os_str().as_bytes(), 0)
         .map_err(|err| io::Error::from_raw_os_error(err.errno))?;
     set_file_times_redox(fd, atime, mtime)
 }
 
-pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_symlink_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
+    let (atime, mtime) = match (atime, mtime) {
+        (Some(atime), Some(mtime)) => (atime, mtime),
+        (None, None) => return Ok(()),
+        _ => unimplemented!("Must set both atime and mtime on Redox"),
+    };
+
     let fd = syscall::open(p.as_os_str().as_bytes(), syscall::O_NOFOLLOW)
         .map_err(|err| io::Error::from_raw_os_error(err.errno))?;
     set_file_times_redox(fd, atime, mtime)

--- a/src/unix/linux.rs
+++ b/src/unix/linux.rs
@@ -11,15 +11,15 @@ use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
 use FileTime;
 use super::libc::{self, c_int, c_char, timespec};
 
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
     set_times(p, atime, mtime, false)
 }
 
-pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_symlink_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
     set_times(p, atime, mtime, true)
 }
 
-fn set_times(p: &Path, atime: FileTime, mtime: FileTime, symlink: bool) -> io::Result<()> {
+fn set_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>, symlink: bool) -> io::Result<()> {
     let flags = if symlink { libc::AT_SYMLINK_NOFOLLOW } else { 0 };
     let utimes = if symlink { libc::lutimes } else { libc::utimes };
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -31,25 +31,11 @@ cfg_if! {
 
 #[allow(dead_code)]
 fn utimes(p: &Path,
-          atime: Option<FileTime>,
-          mtime: Option<FileTime>,
+          atime: FileTime,
+          mtime: FileTime,
           utimes: unsafe extern fn(*const c_char, *const timeval) -> c_int)
     -> io::Result<()>
 {
-    let atime = if let Some(atime) = atime {
-        atime
-    } else {
-        let meta = p.metadata().expect("file should have metadata");
-        from_last_access_time(&meta)
-    };
-
-    let mtime = if let Some(mtime) = mtime {
-        mtime
-    } else {
-        let meta = p.metadata().expect("file should have metadata");
-        from_last_modification_time(&meta)
-    };
-
     let times = [to_timeval(&atime), to_timeval(&mtime)];
     let p = try!(CString::new(p.as_os_str().as_bytes()));
     return if unsafe { utimes(p.as_ptr() as *const _, times.as_ptr()) == 0 } {

--- a/src/unix/utimensat.rs
+++ b/src/unix/utimensat.rs
@@ -4,10 +4,10 @@ use std::io;
 use FileTime;
 use super::libc;
 
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
     super::utimensat(p, atime, mtime, libc::utimensat, 0)
 }
 
-pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_symlink_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
     super::utimensat(p, atime, mtime, libc::utimensat, libc::AT_SYMLINK_NOFOLLOW)
 }

--- a/src/unix/utimes.rs
+++ b/src/unix/utimes.rs
@@ -5,9 +5,13 @@ use FileTime;
 use super::libc;
 
 pub fn set_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
-    super::utimes(p, atime, mtime, libc::utimes)
+    // Safe to unwrap atime and mtime -- platforms which use the utimes module
+    // only expose public API functions to set both at once
+    super::utimes(p, atime.unwrap(), mtime.unwrap(), libc::utimes)
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
-    super::utimes(p, atime, mtime, libc::lutimes)
+    // Safe to unwrap atime and mtime -- platforms which use the utimes module
+    // only expose public API functions to set both at once
+    super::utimes(p, atime.unwrap(), mtime.unwrap(), libc::lutimes)
 }

--- a/src/unix/utimes.rs
+++ b/src/unix/utimes.rs
@@ -4,10 +4,10 @@ use std::io;
 use FileTime;
 use super::libc;
 
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
     super::utimes(p, atime, mtime, libc::utimes)
 }
 
-pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_symlink_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
     super::utimes(p, atime, mtime, libc::lutimes)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -7,11 +7,23 @@ use std::path::Path;
 
 use FileTime;
 
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
+    let (atime, mtime) = match (atime, mtime) {
+        (Some(atime), Some(mtime)) => (atime, mtime),
+        (None, None) => return Ok(()),
+        _ => unimplemented!("Must set both atime and mtime on Windows"),
+    };
+
     set_file_times_w(p, atime, mtime, OpenOptions::new())
 }
 
-pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+pub fn set_symlink_file_times(p: &Path, atime: Option<FileTime>, mtime: Option<FileTime>) -> io::Result<()> {
+    let (atime, mtime) = match (atime, mtime) {
+        (Some(atime), Some(mtime)) => (atime, mtime),
+        (None, None) => return Ok(()),
+        _ => unimplemented!("Must set both atime and mtime on Windows"),
+    };
+
     use std::os::windows::fs::OpenOptionsExt;
     const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x00200000;
 


### PR DESCRIPTION
I added `set_file_mtime()` and `set_file_atime()` as requested in #26. I use the `UTIME_OMIT` argument if possible, and fall back to just resetting the omitted time to its current value.

The two new functions are gated for Unix targets only; I haven't implemented Windows or Redox versions as I am not familiar with those operating systems and cannot test them.