### PR TITLE
debug HFS on other systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ filetime = "0.2"
 
 This library includes the ability to set this data, which std does not.
 
-This library, when built with debug_assertions and with the variable `FILETIME_EMULATE_SECOND_ONLY_SYSTEM` set, will return all times rounded down to the second. This emulates the behavior of some file systems, mostly [HFS](https://en.wikipedia.org/wiki/HFS_Plus), allowing debugging on other hardware.
+This library, when built with `RUSTFLAGS=--cfg emulate_second_only_systom` set, will return all times rounded down to the second. This emulates the behavior of some file systems, mostly [HFS](https://en.wikipedia.org/wiki/HFS_Plus), allowing debugging on other hardware.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Documentation](https://docs.rs/filetime)
 
-A helper library for inspecting the various timestamps of files in Rust. This
+A helper library for inspecting and seting the various timestamps of files in Rust. This
 library takes into account cross-platform differences in terms of where the
 timestamps are located, what they are called, and how to convert them into a
 platform-independent representation.
@@ -15,6 +15,12 @@ platform-independent representation.
 [dependencies]
 filetime = "0.2"
 ```
+
+# Advantages over using `std::fs::Metadata`
+
+This library includes the ability to set this data, which std dose not.
+
+This library, when built with debug_assertions and with the variable `FILETIME_EMULATE_SECOND_ONLY_SYSTOM` set, will return all times rounded down to the second. This emulates the behavior of some file systems, mostly [HFS](https://en.wikipedia.org/wiki/HFS_Plus), allowing debugging on other hardware.
 
 # License
 
@@ -30,5 +36,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in Filetime by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Documentation](https://docs.rs/filetime)
 
-A helper library for inspecting and seting the various timestamps of files in Rust. This
+A helper library for inspecting and setting the various timestamps of files in Rust. This
 library takes into account cross-platform differences in terms of where the
 timestamps are located, what they are called, and how to convert them into a
 platform-independent representation.
@@ -18,9 +18,9 @@ filetime = "0.2"
 
 # Advantages over using `std::fs::Metadata`
 
-This library includes the ability to set this data, which std dose not.
+This library includes the ability to set this data, which std does not.
 
-This library, when built with debug_assertions and with the variable `FILETIME_EMULATE_SECOND_ONLY_SYSTOM` set, will return all times rounded down to the second. This emulates the behavior of some file systems, mostly [HFS](https://en.wikipedia.org/wiki/HFS_Plus), allowing debugging on other hardware.
+This library, when built with debug_assertions and with the variable `FILETIME_EMULATE_SECOND_ONLY_SYSTEM` set, will return all times rounded down to the second. This emulates the behavior of some file systems, mostly [HFS](https://en.wikipedia.org/wiki/HFS_Plus), allowing debugging on other hardware.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ filetime = "0.2"
 
 This library includes the ability to set this data, which std does not.
 
-This library, when built with `RUSTFLAGS=--cfg emulate_second_only_systom` set, will return all times rounded down to the second. This emulates the behavior of some file systems, mostly [HFS](https://en.wikipedia.org/wiki/HFS_Plus), allowing debugging on other hardware.
+This library, when built with `RUSTFLAGS=--cfg emulate_second_only_system` set, will return all times rounded down to the second. This emulates the behavior of some file systems, mostly [HFS](https://en.wikipedia.org/wiki/HFS_Plus), allowing debugging on other hardware.
 
 # License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ impl FileTime {
         FileTime { seconds: 0, nanos: 0 }
     }
 
-    fn emulate_second_only_systom(self) -> FileTime {
-        if cfg!(debug_assertions) && env::var_os("FILETIME_EMULATE_SECOND_ONLY_SYSTOM").is_some() {
+    fn emulate_second_only_system(self) -> FileTime {
+        if cfg!(debug_assertions) && env::var_os("FILETIME_EMULATE_SECOND_ONLY_SYSTEM").is_some() {
             FileTime {seconds: self.seconds, nanos: 0}
         } else {
             self
@@ -98,7 +98,7 @@ impl FileTime {
         FileTime {
             seconds: seconds + if cfg!(windows) {11644473600} else {0},
             nanos,
-        }.emulate_second_only_systom()
+        }.emulate_second_only_system()
     }
 
     /// Creates a new timestamp from the last modification time listed in the
@@ -107,7 +107,7 @@ impl FileTime {
     /// The returned value corresponds to the `mtime` field of `stat` on Unix
     /// platforms and the `ftLastWriteTime` field on Windows platforms.
     pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {
-        imp::from_last_modification_time(meta).emulate_second_only_systom()
+        imp::from_last_modification_time(meta).emulate_second_only_system()
     }
 
     /// Creates a new timestamp from the last access time listed in the
@@ -116,7 +116,7 @@ impl FileTime {
     /// The returned value corresponds to the `atime` field of `stat` on Unix
     /// platforms and the `ftLastAccessTime` field on Windows platforms.
     pub fn from_last_access_time(meta: &fs::Metadata) -> FileTime {
-        imp::from_last_access_time(meta).emulate_second_only_systom()
+        imp::from_last_access_time(meta).emulate_second_only_system()
     }
 
     /// Creates a new timestamp from the creation time listed in the specified
@@ -127,7 +127,7 @@ impl FileTime {
     /// that not all Unix platforms have this field available and may return
     /// `None` in some circumstances.
     pub fn from_creation_time(meta: &fs::Metadata) -> Option<FileTime> {
-        imp::from_creation_time(meta).map(|x| x.emulate_second_only_systom())
+        imp::from_creation_time(meta).map(|x| x.emulate_second_only_system())
     }
 
     /// Creates a new timestamp from the given SystemTime.
@@ -158,7 +158,7 @@ impl FileTime {
                 seconds: -1 * until_epoch.as_secs() as i64 + sec_offset,
                 nanos
             }
-        }).emulate_second_only_systom()
+        }).emulate_second_only_system()
     }
 
     /// Returns the whole number of seconds represented by this timestamp.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl FileTime {
     }
 
     fn emulate_second_only_system(self) -> FileTime {
-        if cfg!(debug_assertions) && env::var_os("FILETIME_EMULATE_SECOND_ONLY_SYSTEM").is_some() {
+        if cfg!(emulate_second_only_systom) {
             FileTime {seconds: self.seconds, nanos: 0}
         } else {
             self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 #[macro_use]
 extern crate cfg_if;
 
+use std::env;
 use std::fmt;
 use std::fs;
 use std::io;
@@ -75,6 +76,14 @@ impl FileTime {
         FileTime { seconds: 0, nanos: 0 }
     }
 
+    fn emulate_second_only_systom(self) -> FileTime {
+        if cfg!(debug_assertions) && env::var_os("FILETIME_EMULATE_SECOND_ONLY_SYSTOM").is_some() {
+            FileTime {seconds: self.seconds, nanos: 0}
+        } else {
+            self
+        }
+    }
+
     /// Creates a new instance of `FileTime` with a number of seconds and
     /// nanoseconds relative to the Unix epoch, 1970-01-01T00:00:00Z.
     ///
@@ -89,7 +98,7 @@ impl FileTime {
         FileTime {
             seconds: seconds + if cfg!(windows) {11644473600} else {0},
             nanos,
-        }
+        }.emulate_second_only_systom()
     }
 
     /// Creates a new timestamp from the last modification time listed in the
@@ -98,7 +107,7 @@ impl FileTime {
     /// The returned value corresponds to the `mtime` field of `stat` on Unix
     /// platforms and the `ftLastWriteTime` field on Windows platforms.
     pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {
-        imp::from_last_modification_time(meta)
+        imp::from_last_modification_time(meta).emulate_second_only_systom()
     }
 
     /// Creates a new timestamp from the last access time listed in the
@@ -107,7 +116,7 @@ impl FileTime {
     /// The returned value corresponds to the `atime` field of `stat` on Unix
     /// platforms and the `ftLastAccessTime` field on Windows platforms.
     pub fn from_last_access_time(meta: &fs::Metadata) -> FileTime {
-        imp::from_last_access_time(meta)
+        imp::from_last_access_time(meta).emulate_second_only_systom()
     }
 
     /// Creates a new timestamp from the creation time listed in the specified
@@ -118,7 +127,7 @@ impl FileTime {
     /// that not all Unix platforms have this field available and may return
     /// `None` in some circumstances.
     pub fn from_creation_time(meta: &fs::Metadata) -> Option<FileTime> {
-        imp::from_creation_time(meta)
+        imp::from_creation_time(meta).map(|x| x.emulate_second_only_systom())
     }
 
     /// Creates a new timestamp from the given SystemTime.
@@ -149,7 +158,7 @@ impl FileTime {
                 seconds: -1 * until_epoch.as_secs() as i64 + sec_offset,
                 nanos
             }
-        })
+        }).emulate_second_only_systom()
     }
 
     /// Returns the whole number of seconds represented by this timestamp.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl FileTime {
     }
 
     fn emulate_second_only_system(self) -> FileTime {
-        if cfg!(emulate_second_only_systom) {
+        if cfg!(emulate_second_only_system) {
             FileTime {seconds: self.seconds, nanos: 0}
         } else {
             self


### PR DESCRIPTION
This is a follow up to the iday from https://github.com/rust-lang/cargo/pull/6484#issuecomment-451601874

This adds a `FILETIME_EMULATE_SECOND_ONLY_SYSTEM`, that allows debugging HFS from other hardware.