### PR TITLE
Do not crash when compiling to wasm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ cfg_if! {
     } else if #[cfg(windows)] {
         #[path = "windows.rs"]
         mod imp;
+    } else if #[cfg(target_arch = "wasm32")] {
+        #[path = "wasm.rs"]
+        mod imp;
     } else {
         #[path = "unix/mod.rs"]
         mod imp;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,26 @@
+#![allow(unused_variables)]
+#![allow(bad_style)]
+
+use std::path::Path;
+use std::{fs, io};
+use FileTime;
+
+pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+    unimplemented!()
+}
+
+pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+    unimplemented!()
+}
+
+pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {
+    unimplemented!()
+}
+
+pub fn from_last_access_time(meta: &fs::Metadata) -> FileTime {
+    unimplemented!()
+}
+
+pub fn from_creation_time(meta: &fs::Metadata) -> Option<FileTime> {
+    unimplemented!()
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -6,11 +6,11 @@ use std::{fs, io};
 use FileTime;
 
 pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    unimplemented!()
+    Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    unimplemented!()
+    Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
 }
 
 pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {


### PR DESCRIPTION
Provide `unimplemented` functions for wasm32 target. This prevents from crashing when compiling filetime as a dependency of tar-rs. If any of these functions get called though, the program will crash at runtime.