### PR TITLE
Enable utimensat for macos target OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ matrix:
     - os: osx
       osx_image: xcode9.2
     - os: osx
-      osx_image: xcode9.4
-    - os: osx
-      osx_image: xcode10
-    - os: osx
       osx_image: xcode11
     - rust: beta
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ matrix:
   include:
     - rust: stable
     - os: osx
+      osx_image: xcode9.2
+    - os: osx
+      osx_image: xcode9.4
+    - os: osx
+      osx_image: xcode10
+    - os: osx
+      osx_image: xcode11
     - rust: beta
     - rust: nightly
 

--- a/src/unix/macos.rs
+++ b/src/unix/macos.rs
@@ -1,0 +1,126 @@
+//! Beginning with MacOS 10.3, `utimensat` is supported by the MacOS, so here, we check if the symbol exists
+//! and if not, we fallabck to `utimes`.
+use crate::FileTime;
+use libc::{c_char, c_int, timespec};
+use std::ffi::CString;
+use std::fs::File;
+use std::os::unix::prelude::*;
+use std::path::Path;
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::{io, mem};
+
+pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+    set_times(p, Some(atime), Some(mtime), false)
+}
+
+pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
+    set_times(p, None, Some(mtime), false)
+}
+
+pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
+    set_times(p, Some(atime), None, false)
+}
+
+pub fn set_file_handle_times(
+    f: &File,
+    atime: Option<FileTime>,
+    mtime: Option<FileTime>,
+) -> io::Result<()> {
+    // Attempt to use the `futimens` syscall, but if it's not supported by the
+    // current kernel then fall back to an older syscall.
+    static INVALID: AtomicBool = AtomicBool::new(false);
+    if !INVALID.load(SeqCst) {
+        if let Some(func) = futimens() {
+            let times = [super::to_timespec(&atime), super::to_timespec(&mtime)];
+            let rc = unsafe { func(f.as_raw_fd(), times.as_ptr()) };
+            if rc == 0 {
+                return Ok(());
+            } else {
+                return Err(io::Error::last_os_error());
+            }
+        } else {
+            INVALID.store(true, SeqCst);
+        }
+    }
+
+    super::utimes::set_file_handle_times(f, atime, mtime)
+}
+
+pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
+    set_times(p, Some(atime), Some(mtime), true)
+}
+
+fn set_times(
+    p: &Path,
+    atime: Option<FileTime>,
+    mtime: Option<FileTime>,
+    symlink: bool,
+) -> io::Result<()> {
+    // Attempt to use the `utimensat` syscall, but if it's not supported by the
+    // current kernel then fall back to an older syscall.
+    static INVALID: AtomicBool = AtomicBool::new(false);
+    if !INVALID.load(SeqCst) {
+        if let Some(func) = utimensat() {
+            let flags = if symlink {
+                libc::AT_SYMLINK_NOFOLLOW
+            } else {
+                0
+            };
+
+            let p = CString::new(p.as_os_str().as_bytes())?;
+            let times = [super::to_timespec(&atime), super::to_timespec(&mtime)];
+            let rc = unsafe { func(libc::AT_FDCWD, p.as_ptr(), times.as_ptr(), flags) };
+            if rc == 0 {
+                return Ok(());
+            } else {
+                return Err(io::Error::last_os_error());
+            }
+        } else {
+            INVALID.store(true, SeqCst);
+        }
+    }
+
+    super::utimes::set_times(p, atime, mtime, symlink)
+}
+
+fn utimensat() -> Option<unsafe extern "C" fn(c_int, *const c_char, *const timespec, c_int) -> c_int>
+{
+    static ADDR: AtomicUsize = AtomicUsize::new(0);
+    unsafe {
+        match ADDR.load(SeqCst) {
+            0 => {}
+            1 => return None,
+            n => return Some(mem::transmute(n)),
+        }
+        let name = b"utimensat\0";
+        let sym = libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr() as *const _);
+        let (val, ret) = if sym.is_null() {
+            (1, None)
+        } else {
+            (sym as usize, Some(mem::transmute(sym)))
+        };
+        ADDR.store(val, SeqCst);
+        return ret;
+    }
+}
+
+fn futimens() -> Option<unsafe extern "C" fn(c_int, *const timespec) -> c_int> {
+    static ADDR: AtomicUsize = AtomicUsize::new(0);
+    unsafe {
+        match ADDR.load(SeqCst) {
+            0 => {}
+            1 => return None,
+            n => return Some(mem::transmute(n)),
+        }
+        let name = b"futimens\0";
+        let sym = libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr() as *const _);
+        let (val, ret) = if sym.is_null() {
+            (1, None)
+        } else {
+            (sym as usize, Some(mem::transmute(sym)))
+        };
+        ADDR.store(val, SeqCst);
+        return ret;
+    }
+}


### PR DESCRIPTION
This PR enables `utimensat` for MacOS target. It's probably not done in the most ergonomic way possible but I'm happy to work on it until it meets the expectations :-) Anyhow, it fixes problems with MacOS target in CraneStation/wasi-common#54.

cc @marmistrz @alexcrichton 