### PR TITLE
Update crate version in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! filetime = "0.1"
+//! filetime = "0.2"
 //! ```
 //!
 //! # Usage


### PR DESCRIPTION
Now, matches the actual version of the crate which is `0.2`.