### PR TITLE
Add illumos target support

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -14,6 +14,7 @@ cfg_if::cfg_if! {
         pub use self::macos::*;
     } else if #[cfg(any(target_os = "android",
                         target_os = "solaris",
+                        target_os = "illumos",
                         target_os = "emscripten",
                         target_os = "freebsd",
                         target_os = "netbsd",


### PR DESCRIPTION
As part of the preparation for rust-lang/rust#55553, add support for the Solaris-like illumos target.