### PR TITLE
Fix PermissionDenied error with Windows folders

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -9,17 +9,26 @@ use winapi::um::fileapi::*;
 use winapi::um::winbase::*;
 
 pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    let f = OpenOptions::new().write(true).open(p)?;
+    let f = OpenOptions::new()
+        .write(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(p)?;
     set_file_handle_times(&f, Some(atime), Some(mtime))
 }
 
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
-    let f = OpenOptions::new().write(true).open(p)?;
+    let f = OpenOptions::new()
+        .write(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(p)?;
     set_file_handle_times(&f, None, Some(mtime))
 }
 
 pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
-    let f = OpenOptions::new().write(true).open(p)?;
+    let f = OpenOptions::new()
+        .write(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(p)?;
     set_file_handle_times(&f, Some(atime), None)
 }
 
@@ -64,7 +73,7 @@ pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io:
 
     let f = OpenOptions::new()
         .write(true)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)
         .open(p)?;
     set_file_handle_times(&f, Some(atime), Some(mtime))
 }


### PR DESCRIPTION
Currently, a `PermissionDenied` error is raised when using `set_file_times`, `set_file_mtime`, `set_file_atime` or `set_symlink_file_times` and passing a path to a folder on Windows.
Passing the [`FILE_FLAG_BACKUP_SEMANTICS`](https://docs.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights) flag when opening the file handle fixes the issue.

This PR also adds tests for setting directory times.