### PR TITLE
utimensat.rs: remove use of futimens

### DIFF
--- a/src/unix/utimensat.rs
+++ b/src/unix/utimensat.rs
@@ -23,7 +23,7 @@ pub fn set_file_handle_times(
     mtime: Option<FileTime>,
 ) -> io::Result<()> {
     let times = [super::to_timespec(&atime), super::to_timespec(&mtime)];
-    let rc = unsafe { libc::futimens(f.as_raw_fd(), times.as_ptr()) };
+    let rc = unsafe { libc::utimensat(f.as_raw_fd(), core::ptr::null(), times.as_ptr(), 0) };
     if rc == 0 {
         Ok(())
     } else {


### PR DESCRIPTION
`futimens` is not available in Android NDK before version 19:
https://stackoverflow.com/questions/19374749/how-to-work-around-absence-of-futimes-in-android-ndk

The reason is that bionic libc didn't implement this wrapper for
`utimensat`.

`utimensat` syscall was available before that, so it is more compatible.

Fixes #56