### PR TITLE
Do not include utimes module on android

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,15 @@ jobs:
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check
 
+  android_build:
+    name: Android build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update stable && rustup default stable && rustup target add x86_64-linux-android
+    - run: cargo build --target x86_64-linux-android
+
   publish_docs:
     name: Publish Documentation
     runs-on: ubuntu-latest

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -9,7 +9,6 @@ cfg_if::cfg_if! {
         mod linux;
         pub use self::linux::*;
     } else if #[cfg(target_os = "android")] {
-        mod utimes;
         mod android;
         pub use self::android::*;
     } else if #[cfg(target_os = "macos")] {


### PR DESCRIPTION
Android variant is a copy of utimensat with a modification to remove
futimens call, so it should follow the pattern used for utimensat module
used for "solaris, illumos, ..." case.

Follow-up for #59 

Fixes #62