### PR TITLE
widen version bound for cfg-if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ Platform-agnostic accessors of timestamps in File metadata
 edition = "2018"
 
 [dependencies]
-cfg-if = "1.0.0"
+cfg-if = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"


### PR DESCRIPTION
This will allow cargo to use a more recent version of `cfg-if`, and use fewer versions of `cfg-if` if it's used elsewhere in the crate graph