### PR TITLE
Adapt to UTF-8 only paths in redox_syscall 0.2.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2.27"
 winapi = { version = '0.3', features = ['fileapi', 'minwindef', 'winbase'] }
 
 [target.'cfg(target_os = "redox")'.dependencies]
-redox_syscall = "0.2"
+redox_syscall = "0.2.8"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
This fixes building on new versions of Redox