### PR TITLE
fix Android symlink flag

### DIFF
--- a/src/unix/android.rs
+++ b/src/unix/android.rs
@@ -37,7 +37,7 @@ pub fn set_file_handle_times(
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), Some(mtime), false)
+    set_times(p, Some(atime), Some(mtime), true)
 }
 
 fn set_times(


### PR DESCRIPTION
This gets `cargo test` to pass on Android (previously it failed on the two symlink tests).