### PR TITLE
Bump to 0.2.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "filetime"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.2.15"
+version = "0.2.16"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["timestamp", "mtime"]


### PR DESCRIPTION
The Android fix is currently on the list of things blocking Android support at https://github.com/uutils/coreutils/pull/3396.