### PR TITLE
Migrate from winapi to windows-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,12 @@ cfg-if = "1.0.0"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = '0.3', features = ['fileapi', 'minwindef', 'winbase'] }
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem"
+]
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.2.9"

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,9 +4,8 @@ use std::io;
 use std::os::windows::prelude::*;
 use std::path::Path;
 use std::ptr;
-use winapi::shared::minwindef::*;
-use winapi::um::fileapi::*;
-use winapi::um::winbase::*;
+use windows_sys::Win32::Foundation::{FILETIME, HANDLE};
+use windows_sys::Win32::Storage::FileSystem::*;
 
 pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
     let f = OpenOptions::new()
@@ -41,7 +40,7 @@ pub fn set_file_handle_times(
     let mtime = mtime.map(to_filetime);
     return unsafe {
         let ret = SetFileTime(
-            f.as_raw_handle() as *mut _,
+            f.as_raw_handle() as HANDLE,
             ptr::null(),
             atime
                 .as_ref()
@@ -62,8 +61,8 @@ pub fn set_file_handle_times(
     fn to_filetime(ft: FileTime) -> FILETIME {
         let intervals = ft.seconds() * (1_000_000_000 / 100) + ((ft.nanoseconds() as i64) / 100);
         FILETIME {
-            dwLowDateTime: intervals as DWORD,
-            dwHighDateTime: (intervals >> 32) as DWORD,
+            dwLowDateTime: intervals as u32,
+            dwHighDateTime: (intervals >> 32) as u32,
         }
     }
 }


### PR DESCRIPTION
This PR migrates remove-dir-all from winapi to windows-sys.

Windows-sys is actively maintained, by Microsoft, and has recently
started to be adopted in the ecosystem; mio, parking_lot, wasmtime,
and others have moved to windows-sys.