### PR TITLE
Correct the timestamp of symlink if using `utimensat`

### DIFF
--- a/src/unix/utimensat.rs
+++ b/src/unix/utimensat.rs
@@ -32,7 +32,7 @@ pub fn set_file_handle_times(
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), Some(mtime), false)
+    set_times(p, Some(atime), Some(mtime), true)
 }
 
 fn set_times(


### PR DESCRIPTION
IIUC, we are setting the timestamp of the symlink file rather than the target file. So the flag should be `true` as linux.