### PR TITLE
Update use of libc::timespec to prepare for future libc version

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -58,17 +58,16 @@ fn to_timespec(ft: &Option<FileTime>) -> timespec {
         }
     }
 
+    let mut ts: timespec = unsafe { std::mem::zeroed() };
     if let &Some(ft) = ft {
-        timespec {
-            tv_sec: ft.seconds() as time_t,
-            tv_nsec: ft.nanoseconds() as _,
-        }
+        ts.tv_sec = ft.seconds() as time_t;
+        ts.tv_nsec = ft.nanoseconds() as _;
     } else {
-        timespec {
-            tv_sec: 0,
-            tv_nsec: UTIME_OMIT as _,
-        }
+        ts.tv_sec = 0;
+        ts.tv_nsec = UTIME_OMIT as _;
     }
+
+    ts
 }
 
 pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {


### PR DESCRIPTION
In a future release of the `libc` crate, `libc::timespec` will contain private padding fields on `*-linux-musl` targets and so the struct will no longer be able to be created using the literal initialization syntax.

Update struct literal use of `libc::timespec` to initialize to zero first and then manually update the appropriate fields. Also updates a raw syscall to use the libc function instead as on musl 1.2, it correctly handles `libc::timespec` values which, in musl 1.2, are always 16 bytes in length regardless of platform.

See also https://github.com/rust-lang/libc/pull/2088