### PR TITLE
Replace redox_syscall with libredox.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "redox")'.dependencies]
-redox_syscall = "0.4.1"
+libredox = "0.1.0"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Libredox is the new recommended Redox API (the other one being `libc`) , now that Redox no longer guarantees its syscall ABI to be stable.