### PR TITLE
redox: relax type requirement for tv_nsec, fixing x86 32-bit

### DIFF
--- a/src/redox.rs
+++ b/src/redox.rs
@@ -84,7 +84,7 @@ fn set_file_times_redox(fd: usize, atime: FileTime, mtime: FileTime) -> io::Resu
     fn to_timespec(ft: &FileTime) -> TimeSpec {
         TimeSpec {
             tv_sec: ft.seconds(),
-            tv_nsec: ft.nanoseconds() as i64,
+            tv_nsec: ft.nanoseconds() as _,
         }
     }
 


### PR DESCRIPTION
The type is c_long on some platforms and i64 on others.