### PR TITLE
Enable setting file times for any writable files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,13 +253,7 @@ pub fn set_file_times_now<P>(p: P, follow_symlink: bool) -> io::Result<()>
 where
     P: AsRef<Path>,
 {
-    // FIXME
-    let time = FileTime::now();
-    if follow_symlink {
-        imp::set_file_times(p.as_ref(), time, time)
-    } else {
-        imp::set_symlink_file_times(p.as_ref(), time, time)
-    }
+    imp::set_file_times_now(p.as_ref(), follow_symlink)
 }
 
 /// Set the last access and modification times for a file handle.
@@ -287,8 +281,7 @@ pub fn set_file_handle_times(
 /// syscall is required to convinve the kernel to update atime/mtime of files
 /// owned by other users.
 pub fn set_file_handle_times_now(f: &fs::File) -> io::Result<()> {
-    let time = FileTime::now();
-    imp::set_file_handle_times(f, Some(time), Some(time)) // FIXME
+    imp::set_file_handle_times_now(f)
 }
 
 /// Set the last access and modification times for a file on the filesystem.

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -15,6 +15,15 @@ pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<
     set_file_times_redox(fd.raw(), atime, mtime)
 }
 
+pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
+    let time = FileTime::now();
+    if follow_symlink {
+        set_file_times(p, time, time)
+    } else {
+        set_symlink_file_times(p, time, time)
+    }
+}
+
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
     let fd = open_redox(p, 0)?;
     let st = fd.stat()?;
@@ -69,6 +78,11 @@ pub fn set_file_handle_times(
         }
     };
     set_file_times_redox(f.as_raw_fd() as usize, atime1, mtime1)
+}
+
+pub fn set_file_handle_times_now(f: &File) -> io::Result<()> {
+    let time = FileTime::now();
+    set_file_handle_times(f, Some(time), Some(time))
 }
 
 fn open_redox(path: &Path, flags: i32) -> Result<Fd> {

--- a/src/unix/android.rs
+++ b/src/unix/android.rs
@@ -9,6 +9,16 @@ pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<
     set_times(p, Some(atime), Some(mtime), false)
 }
 
+pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
+    let time = FileTime::now();
+    // TODO: Do the same trick as on Linux?
+    if follow_symlink {
+        set_file_times(p, time, time)
+    } else {
+        set_symlink_file_times(p, time, time)
+    }
+}
+
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
     set_times(p, None, Some(mtime), false)
 }
@@ -34,6 +44,11 @@ pub fn set_file_handle_times(
     } else {
         Err(io::Error::last_os_error())
     }
+}
+
+pub fn set_file_handle_times_now(f: &File) -> io::Result<()> {
+    let time = FileTime::now();
+    set_file_handle_times(f, Some(time), Some(time)) // TODO: Do the same trick as on Linux?
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {

--- a/src/unix/linux.rs
+++ b/src/unix/linux.rs
@@ -17,13 +17,36 @@ pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<
 }
 
 pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
-    let time = FileTime::now();
-    // FIXME
-    if follow_symlink {
-        set_file_times(p, time, time)
+    let flags = if !follow_symlink {
+        libc::AT_SYMLINK_NOFOLLOW
     } else {
-        set_symlink_file_times(p, time, time)
+        0
+    };
+
+    // Same as `set_file_handle_times` below.
+    static INVALID: AtomicBool = AtomicBool::new(false);
+    if !INVALID.load(SeqCst) {
+        let p = CString::new(p.as_os_str().as_bytes())?;
+        let rc = unsafe {
+            libc::utimensat(
+                libc::AT_FDCWD,
+                p.as_ptr(),
+                ptr::null::<libc::timespec>(),
+                flags,
+            )
+        };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ENOSYS) {
+            INVALID.store(true, SeqCst);
+        } else {
+            return Err(err);
+        }
     }
+
+    super::utimes::set_file_times_now(p, follow_symlink)
 }
 
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
@@ -91,8 +114,56 @@ pub fn set_file_handle_times(
 }
 
 pub fn set_file_handle_times_now(f: &fs::File) -> io::Result<()> {
-    let time = FileTime::now();
-    set_file_handle_times(f, Some(time), Some(time)) // FIXME
+    eprintln!("Begin linux::set_file_handle_times_now");
+    // Same as `set_file_handle_times` above.
+    static INVALID: AtomicBool = AtomicBool::new(false);
+    if !INVALID.load(SeqCst) {
+        // We normally use a syscall because the `utimensat` function is documented
+        // as not accepting a file descriptor in the first argument (even though, on
+        // Linux, the syscall itself can accept a file descriptor there).
+        #[cfg(not(target_env = "musl"))]
+        let rc = unsafe {
+            eprintln!("linux::set_file_handle_times_now calling non-musl thing");
+            libc::syscall(
+                libc::SYS_utimensat,
+                f.as_raw_fd(),
+                ptr::null::<libc::c_char>(),
+                ptr::null::<libc::timespec>(),
+                0,
+            )
+        };
+        // However, on musl, we call the musl libc function instead. This is because
+        // on newer musl versions starting with musl 1.2, `timespec` is always a 64-bit
+        // value even on 32-bit targets. As a result, musl internally converts their
+        // `timespec` values to the correct ABI before invoking the syscall. Since we
+        // use `timespec` from the libc crate, it matches musl's definition and not
+        // the Linux kernel's version (for some platforms) so we must use musl's
+        // `utimensat` function to properly convert the value. musl's `utimensat`
+        // function allows file descriptors in the path argument so this is fine.
+        #[cfg(target_env = "musl")]
+        let rc = unsafe {
+            libc::utimensat(
+                f.as_raw_fd(),
+                ptr::null::<libc::c_char>(),
+                ptr::null::<libc::timespec>(),
+                0,
+            )
+        };
+
+        eprintln!("linux::set_file_handle_times_now inner done");
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ENOSYS) {
+            INVALID.store(true, SeqCst);
+        } else {
+            return Err(err);
+        }
+    }
+
+    eprintln!("linux::set_file_handle_times_now FALLING BACK!!!");
+    super::utimes::set_file_handle_times_now(f)
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
@@ -111,7 +182,7 @@ fn set_times(
         0
     };
 
-    // Same as the `if` statement above.
+    // Same as `set_file_handle_times` above.
     static INVALID: AtomicBool = AtomicBool::new(false);
     if !INVALID.load(SeqCst) {
         let p = CString::new(p.as_os_str().as_bytes())?;

--- a/src/unix/linux.rs
+++ b/src/unix/linux.rs
@@ -16,6 +16,16 @@ pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<
     set_times(p, Some(atime), Some(mtime), false)
 }
 
+pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
+    let time = FileTime::now();
+    // FIXME
+    if follow_symlink {
+        set_file_times(p, time, time)
+    } else {
+        set_symlink_file_times(p, time, time)
+    }
+}
+
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
     set_times(p, None, Some(mtime), false)
 }
@@ -78,6 +88,11 @@ pub fn set_file_handle_times(
     }
 
     super::utimes::set_file_handle_times(f, atime, mtime)
+}
+
+pub fn set_file_handle_times_now(f: &fs::File) -> io::Result<()> {
+    let time = FileTime::now();
+    set_file_handle_times(f, Some(time), Some(time)) // FIXME
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {

--- a/src/unix/macos.rs
+++ b/src/unix/macos.rs
@@ -14,6 +14,16 @@ pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<
     set_times(p, Some(atime), Some(mtime), false)
 }
 
+pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
+    let time = FileTime::now();
+    // TODO: Do the same trick as on Linux?
+    if follow_symlink {
+        set_file_times(p, time, time)
+    } else {
+        set_symlink_file_times(p, time, time)
+    }
+}
+
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
     set_times(p, None, Some(mtime), false)
 }
@@ -40,6 +50,11 @@ pub fn set_file_handle_times(
     }
 
     super::utimes::set_file_handle_times(f, atime, mtime)
+}
+
+pub fn set_file_handle_times_now(f: &File) -> io::Result<()> {
+    let time = FileTime::now();
+    set_file_handle_times(f, Some(time), Some(time)) // TODO: Do the same trick as on Linux?
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {

--- a/src/unix/utimensat.rs
+++ b/src/unix/utimensat.rs
@@ -9,6 +9,16 @@ pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<
     set_times(p, Some(atime), Some(mtime), false)
 }
 
+pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
+    let time = FileTime::now();
+    // TODO: Do the same trick as on Linux?
+    if follow_symlink {
+        set_file_times(p, time, time)
+    } else {
+        set_symlink_file_times(p, time, time)
+    }
+}
+
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
     set_times(p, None, Some(mtime), false)
 }
@@ -29,6 +39,11 @@ pub fn set_file_handle_times(
     } else {
         Err(io::Error::last_os_error())
     }
+}
+
+pub fn set_file_handle_times_now(f: &File) -> io::Result<()> {
+    let time = FileTime::now();
+    set_file_handle_times(f, Some(time), Some(time)) // TODO: Do the same trick as on Linux?
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {

--- a/src/unix/utimensat.rs
+++ b/src/unix/utimensat.rs
@@ -4,18 +4,38 @@ use std::fs::File;
 use std::io;
 use std::os::unix::prelude::*;
 use std::path::Path;
+use std::ptr;
 
 pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
     set_times(p, Some(atime), Some(mtime), false)
 }
 
 pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
-    let time = FileTime::now();
-    // TODO: Do the same trick as on Linux?
-    if follow_symlink {
-        set_file_times(p, time, time)
+    let flags = if !follow_symlink {
+        if cfg!(target_os = "emscripten") {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "emscripten does not support utimensat for symlinks",
+            ));
+        }
+        libc::AT_SYMLINK_NOFOLLOW
     } else {
-        set_symlink_file_times(p, time, time)
+        0
+    };
+
+    let p = CString::new(p.as_os_str().as_bytes())?;
+    let rc = unsafe {
+        libc::utimensat(
+            libc::AT_FDCWD,
+            p.as_ptr(),
+            ptr::null::<libc::timespec>(),
+            flags,
+        )
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
     }
 }
 
@@ -42,8 +62,12 @@ pub fn set_file_handle_times(
 }
 
 pub fn set_file_handle_times_now(f: &File) -> io::Result<()> {
-    let time = FileTime::now();
-    set_file_handle_times(f, Some(time), Some(time)) // TODO: Do the same trick as on Linux?
+    let rc = unsafe { libc::futimens(f.as_raw_fd(), ptr::null::<libc::timespec>()) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {

--- a/src/unix/utimes.rs
+++ b/src/unix/utimes.rs
@@ -11,6 +11,17 @@ pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<
 }
 
 #[allow(dead_code)]
+pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
+    let time = FileTime::now();
+    // TODO: Do the same trick as on Linux?
+    if follow_symlink {
+        set_file_times(p, time, time)
+    } else {
+        set_symlink_file_times(p, time, time)
+    }
+}
+
+#[allow(dead_code)]
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
     set_times(p, None, Some(mtime), false)
 }
@@ -58,6 +69,12 @@ pub fn set_file_handle_times(
     } else {
         Err(io::Error::last_os_error())
     };
+}
+
+#[allow(dead_code)]
+pub fn set_file_handle_times_now(f: &fs::File) -> io::Result<()> {
+    let time = FileTime::now();
+    set_file_handle_times(f, Some(time), Some(time)) // TODO: Do the same trick as on Linux?
 }
 
 fn get_times(

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -7,6 +7,10 @@ pub fn set_file_times(_p: &Path, _atime: FileTime, _mtime: FileTime) -> io::Resu
     Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
 }
 
+pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
+    Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
+}
+
 pub fn set_symlink_file_times(_p: &Path, _atime: FileTime, _mtime: FileTime) -> io::Result<()> {
     Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
 }
@@ -36,5 +40,9 @@ pub fn set_file_handle_times(
     _atime: Option<FileTime>,
     _mtime: Option<FileTime>,
 ) -> io::Result<()> {
+    Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
+}
+
+pub fn set_file_handle_times_now(_f: &File) -> io::Result<()> {
     Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,6 +15,15 @@ pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<
     set_file_handle_times(&f, Some(atime), Some(mtime))
 }
 
+pub fn set_file_times_now(p: &Path, follow_symlink: bool) -> io::Result<()> {
+    let time = FileTime::now();
+    if follow_symlink {
+        set_file_times(p, time, time)
+    } else {
+        set_symlink_file_times(p, time, time)
+    }
+}
+
 pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
     let f = OpenOptions::new()
         .write(true)
@@ -65,6 +74,11 @@ pub fn set_file_handle_times(
             dwHighDateTime: (intervals >> 32) as u32,
         }
     }
+}
+
+pub fn set_file_handle_times_now(f: &File) -> io::Result<()> {
+    let time = FileTime::now();
+    set_file_handle_times(f, Some(time), Some(time))
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {


### PR DESCRIPTION
This PR enables calling (f)utime(n)s(at) in a special way that was not possible before.

In particular, POSIX [specifies](https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimensat.html) that when `times` is a nullptr, then utimensat only requires that the caller has write access to the file. This cannot be emulated by any other function of this crate, as they always pass a userspace-provided `times` struct, which requires the caller to be the *owner* of the file.

This PR adds two new functions to the API: `set_file_times_now(p: &Path, follow_symlink: bool)` and `set_file_handle_times_now(f: &fs::File)`.
- On linux/utimens/utimes, it uses the appropriate (f)utime(n)s(at) variant to pull off the trick.
    * I checked each of the three variants with both Linux 4.9 and Linux 6.6.
    * I don't have a way to check that this works as intended on aix, solaris, illumos, emscripten, freebsd, netbsd, openbsd, haiku. How do I check this?
- Android and MacOS *should* be posix-y enough to allow for this to work, too, but I don't feel adventurous enough to try it out. I implemented it using trivial wrappers, and included a TODO for the next person who cares to look into it.
- Redox, android, Windows use trivial wrappers, as the feature does not apply here.
- wasm lacks even the basic functionality, so I copy-pasted the "Wasm not implemented" error.

Fun fact: I'm trying to work on [the Rust coreutils](https://github.com/uutils/coreutils), and this feature is required to implement `touch` in a way that passes the [`touch/now-owned-by-other`](https://github.com/coreutils/coreutils/blob/master/tests/touch/now-owned-by-other.sh#L32) test.