### PR TITLE
Update windows-sys to 0.61 or earlier

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: cargo test
+    - run: cargo +nightly update -Zminimal-versions && cargo test
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cfg-if = "1.0.0"
 libc = "0.2.27"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.60.0"
+version = ">=0.28, <=0.61"
 features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem"


### PR DESCRIPTION
windows-sys is a frequent source of duplicate dependencies.  Widening the range of allowed versions gives downstream crates a fighting chance of being able to select one unique version of it.

Allowing windows-sys 0.36 also permits building with Rust 1.46 on Windows.