### PR TITLE
Solaris uses incorrect UTIME_OMIT value, causing EINVAL when setting file times

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1,5 +1,5 @@
 use crate::FileTime;
-use libc::{time_t, timespec};
+use libc::{time_t, timespec, UTIME_OMIT};
 use std::fs;
 use std::os::unix::prelude::*;
 
@@ -33,31 +33,6 @@ cfg_if::cfg_if! {
 
 #[allow(dead_code)]
 fn to_timespec(ft: &Option<FileTime>) -> timespec {
-    cfg_if::cfg_if! {
-        if #[cfg(any(target_os = "macos",
-                     target_os = "illumos",
-                     target_os = "freebsd"))] {
-            // https://github.com/apple/darwin-xnu/blob/a449c6a3b8014d9406c2ddbdc81795da24aa7443/bsd/sys/stat.h#L541
-            // https://github.com/illumos/illumos-gate/blob/master/usr/src/boot/sys/sys/stat.h#L312
-            // https://svnweb.freebsd.org/base/head/sys/sys/stat.h?view=markup#l359
-            const UTIME_OMIT: i64 = -2;
-        } else if #[cfg(target_os = "openbsd")] {
-            // https://github.com/openbsd/src/blob/master/sys/sys/stat.h#L189
-            const UTIME_OMIT: i64 = -1;
-        } else if #[cfg(target_os = "haiku")] {
-            // https://git.haiku-os.org/haiku/tree/headers/posix/sys/stat.h?#n106
-            const UTIME_OMIT: i64 = 1000000001;
-        } else if #[cfg(target_os = "aix")] {
-            // AIX hasn't disclosed system header files yet.
-            // https://github.com/golang/go/blob/master/src/cmd/vendor/golang.org/x/sys/unix/zerrors_aix_ppc64.go#L1007
-            const UTIME_OMIT: i64 = -3;
-        } else {
-            // http://cvsweb.netbsd.org/bsdweb.cgi/src/sys/sys/stat.h?annotate=1.68.30.1
-            // https://github.com/emscripten-core/emscripten/blob/master/system/include/libc/sys/stat.h#L71
-            const UTIME_OMIT: i64 = 1_073_741_822;
-        }
-    }
-
     let mut ts: timespec = unsafe { std::mem::zeroed() };
     if let &Some(ft) = ft {
         ts.tv_sec = ft.seconds() as time_t;


### PR DESCRIPTION
## Summary

On Solaris, `set_file_mtime()` and other functions that use `UTIME_OMIT` fail with `EINVAL` (Invalid argument) because an incorrect value is used for the `UTIME_OMIT` constant.

## Environment

- OS: Solaris (not illumos)
- filetime version: 0.2.x

## Problem

When calling `set_file_mtime()`, the `atime` parameter is `None`, which causes `to_timespec()` to set `tv_nsec = UTIME_OMIT`. On Solaris, this results in `EINVAL` from the `utimensat()` syscall.

## Root Cause

In `src/unix/mod.rs`, the `to_timespec()` function defines `UTIME_OMIT` values per platform:

```rust
cfg_if::cfg_if! {
    if #[cfg(any(target_os = "macos",
                 target_os = "illumos",
                 target_os = "freebsd"))] {
        const UTIME_OMIT: i64 = -2;
    } else if #[cfg(target_os = "openbsd")] {
        const UTIME_OMIT: i64 = -1;
    } else if #[cfg(target_os = "haiku")] {
        const UTIME_OMIT: i64 = 1000000001;
    } else if #[cfg(target_os = "aix")] {
        const UTIME_OMIT: i64 = -3;
    } else {
        const UTIME_OMIT: i64 = 1_073_741_822;  // Solaris falls here
    }
}
```

**Solaris is not included in the `illumos` condition**, so it falls through to the `else` branch and uses `1_073_741_822`.

However, Solaris uses the same value as illumos: `UTIME_OMIT = -2`

This can be confirmed in the [illumos stat.h header](https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/stat.h):

```c
#define UTIME_NOW       -1L
#define UTIME_OMIT      -2L
```

illumos is a fork of OpenSolaris, and Oracle Solaris shares the same definitions.

When `tv_nsec = 1_073_741_822` is passed to `utimensat()`, the Solaris kernel rejects it because:
- Valid `tv_nsec` range is `[0, 999_999_999]`
- Special values like `UTIME_OMIT` must be `-2` on Solaris
- `1_073_741_822` is neither a valid nanosecond value nor a recognized special value

## Proposed Fix

Add `target_os = "solaris"` to the same condition as `illumos`:

```rust
if #[cfg(any(target_os = "macos",
             target_os = "illumos",
             target_os = "solaris",  // Add this
             target_os = "freebsd"))] {
    const UTIME_OMIT: i64 = -2;
}
```

## References

- [illumos stat.h - UTIME_OMIT definition](https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/stat.h)
- [gnulib Solaris UTIME_OMIT workaround discussion](https://lists.gnu.org/archive/html/bug-gnulib/2013-05/msg00000.html)
- [Oracle Solaris utimensat(2) man page](https://docs.oracle.com/cd/E88353_01/html/E37841/utimensat-2.html)