### PR TITLE
Add QNX Neutrino (nto) to utimensat platform list

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -16,6 +16,7 @@ cfg_if::cfg_if! {
         mod macos;
         pub use self::macos::*;
     } else if #[cfg(any(target_os = "aix",
+                        target_os = "nto",
                         target_os = "solaris",
                         target_os = "illumos",
                         target_os = "emscripten",


### PR DESCRIPTION
QNX Neutrino implements utimensat(2) and futimens(2) and exports UTIME_OMIT in its libc bindings. Route it through the utimensat path instead of falling through to the utimes fallback which uses lutimes/futimes — neither of which exist in the QNX libc.