### PR TITLE
Use the standard library for most of the crate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,15 @@ jobs:
       shell: bash
     - run: cargo test
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update 1.75.0 && rustup default 1.75.0
+    - run: cargo build
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = """
 Platform-agnostic accessors of timestamps in File metadata
 """
 edition = "2018"
+rust-version = "1.75.0"
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -19,8 +20,11 @@ cfg-if = "1.0.0"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"
 
-[target.'cfg(target_os = "redox")'.dependencies]
-libredox = "0.1.0"
-
 [dev-dependencies]
 tempfile = "3"
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  'cfg(emulate_second_only_system)',
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,11 @@ pub fn set_file_times<P>(p: P, atime: FileTime, mtime: FileTime) -> io::Result<(
 where
     P: AsRef<Path>,
 {
-    imp::set_file_times(p.as_ref(), atime, mtime)
+    imp::open(p.as_ref())?.set_times(
+        fs::FileTimes::new()
+            .set_accessed(atime.into())
+            .set_modified(mtime.into()),
+    )
 }
 
 /// Set the last access and modification times for a file handle.
@@ -262,7 +266,14 @@ pub fn set_file_handle_times(
     atime: Option<FileTime>,
     mtime: Option<FileTime>,
 ) -> io::Result<()> {
-    imp::set_file_handle_times(f, atime, mtime)
+    let mut times = fs::FileTimes::new();
+    if let Some(t) = atime {
+        times = times.set_accessed(t.into());
+    }
+    if let Some(t) = mtime {
+        times = times.set_modified(t.into());
+    }
+    f.set_times(times)
 }
 
 /// Set the last access and modification times for a file on the filesystem.
@@ -291,7 +302,7 @@ pub fn set_file_mtime<P>(p: P, mtime: FileTime) -> io::Result<()>
 where
     P: AsRef<Path>,
 {
-    imp::set_file_mtime(p.as_ref(), mtime)
+    imp::open(p.as_ref())?.set_times(fs::FileTimes::new().set_modified(mtime.into()))
 }
 
 /// Set the last access time for a file on the filesystem.
@@ -308,7 +319,7 @@ pub fn set_file_atime<P>(p: P, atime: FileTime) -> io::Result<()>
 where
     P: AsRef<Path>,
 {
-    imp::set_file_atime(p.as_ref(), atime)
+    imp::open(p.as_ref())?.set_times(fs::FileTimes::new().set_accessed(atime.into()))
 }
 
 #[cfg(test)]
@@ -414,12 +425,6 @@ mod tests {
         let time = FileTime::from_system_time(systime);
         assert_eq!(11644473598, time.seconds);
         assert_eq!(900_000_000, time.nanos);
-        assert_eq!(systime, time.into());
-
-        let systime = UNIX_EPOCH - Duration::from_secs(12_000_000_000);
-        let time = FileTime::from_system_time(systime);
-        assert_eq!(-355526400, time.seconds);
-        assert_eq!(0, time.nanos);
         assert_eq!(systime, time.into());
     }
 
@@ -614,9 +619,6 @@ mod tests {
         let mtime = FileTime::from_last_modification_time(&metadata);
         let atime = FileTime::from_last_access_time(&metadata);
         set_file_times(&path, atime, mtime).unwrap();
-
-        let new_mtime = FileTime::from_unix_time(-12_000_000_000, 0);
-        assert!(set_file_times(&path, atime, new_mtime).is_err());
     }
 
     #[test]

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -1,97 +1,17 @@
 use crate::FileTime;
-use std::fs::{self, File};
+use std::fs::{self};
 use std::io;
 use std::os::unix::prelude::*;
 use std::path::Path;
 
-use libredox::{
-    call, errno,
-    error::{Error, Result},
-    flag, Fd,
-};
-
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    let fd = open_redox(p, 0)?;
-    set_file_times_redox(fd.raw(), atime, mtime)
-}
-
-pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
-    let fd = open_redox(p, 0)?;
-    let st = fd.stat()?;
-
-    set_file_times_redox(
-        fd.raw(),
-        FileTime {
-            seconds: st.st_atime as i64,
-            nanos: st.st_atime_nsec as u32,
-        },
-        mtime,
-    )?;
-    Ok(())
-}
-
-pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
-    let fd = open_redox(p, 0)?;
-    let st = fd.stat()?;
-
-    set_file_times_redox(
-        fd.raw(),
-        atime,
-        FileTime {
-            seconds: st.st_mtime as i64,
-            nanos: st.st_mtime_nsec as u32,
-        },
-    )?;
-    Ok(())
-}
+pub const O_NOFOLLOW: i32 = 0x20000;
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    let fd = open_redox(p, flag::O_NOFOLLOW)?;
-    set_file_times_redox(fd.raw(), atime, mtime)?;
-    Ok(())
-}
-
-pub fn set_file_handle_times(
-    f: &File,
-    atime: Option<FileTime>,
-    mtime: Option<FileTime>,
-) -> io::Result<()> {
-    let (atime1, mtime1) = match (atime, mtime) {
-        (Some(a), Some(b)) => (a, b),
-        (None, None) => return Ok(()),
-        (Some(a), None) => {
-            let meta = f.metadata()?;
-            (a, FileTime::from_last_modification_time(&meta))
-        }
-        (None, Some(b)) => {
-            let meta = f.metadata()?;
-            (FileTime::from_last_access_time(&meta), b)
-        }
-    };
-    set_file_times_redox(f.as_raw_fd() as usize, atime1, mtime1)
-}
-
-fn open_redox(path: &Path, flags: i32) -> Result<Fd> {
-    match path.to_str() {
-        Some(string) => Fd::open(string, flags, 0),
-        None => Err(Error::new(errno::EINVAL)),
-    }
-}
-
-fn set_file_times_redox(fd: usize, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    use libredox::data::TimeSpec;
-
-    fn to_timespec(ft: &FileTime) -> TimeSpec {
-        TimeSpec {
-            tv_sec: ft.seconds(),
-            tv_nsec: ft.nanoseconds() as _,
-        }
-    }
-
-    let times = [to_timespec(&atime), to_timespec(&mtime)];
-
-    call::futimens(fd, &times)?;
-    Ok(())
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(O_NOFOLLOW)
+        .open(p)?;
+    crate::set_file_handle_times(&file, Some(atime), Some(mtime))
 }
 
 pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {
@@ -110,4 +30,8 @@ pub fn from_last_access_time(meta: &fs::Metadata) -> FileTime {
 
 pub fn from_creation_time(_meta: &fs::Metadata) -> Option<FileTime> {
     None
+}
+
+pub fn open(path: &Path) -> io::Result<fs::File> {
+    fs::File::open(path)
 }

--- a/src/unix/android.rs
+++ b/src/unix/android.rs
@@ -1,40 +1,8 @@
 use crate::FileTime;
 use std::ffi::CString;
-use std::fs::File;
 use std::io;
 use std::os::unix::prelude::*;
 use std::path::Path;
-
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), Some(mtime), false)
-}
-
-pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
-    set_times(p, None, Some(mtime), false)
-}
-
-pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), None, false)
-}
-
-pub fn set_file_handle_times(
-    f: &File,
-    atime: Option<FileTime>,
-    mtime: Option<FileTime>,
-) -> io::Result<()> {
-    let times = [super::to_timespec(&atime), super::to_timespec(&mtime)];
-
-    // On Android NDK before version 19, `futimens` is not available.
-    //
-    // For better compatibility, we reimplement `futimens` using `utimensat`,
-    // the same way as bionic libc uses it to implement `futimens`.
-    let rc = unsafe { libc::utimensat(f.as_raw_fd(), core::ptr::null(), times.as_ptr(), 0) };
-    if rc == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
     set_times(p, Some(atime), Some(mtime), true)

--- a/src/unix/linux.rs
+++ b/src/unix/linux.rs
@@ -4,81 +4,11 @@
 
 use crate::FileTime;
 use std::ffi::CString;
-use std::fs;
 use std::io;
 use std::os::unix::prelude::*;
 use std::path::Path;
-use std::ptr;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::SeqCst;
-
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), Some(mtime), false)
-}
-
-pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
-    set_times(p, None, Some(mtime), false)
-}
-
-pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), None, false)
-}
-
-pub fn set_file_handle_times(
-    f: &fs::File,
-    atime: Option<FileTime>,
-    mtime: Option<FileTime>,
-) -> io::Result<()> {
-    // Attempt to use the `utimensat` syscall, but if it's not supported by the
-    // current kernel then fall back to an older syscall.
-    static INVALID: AtomicBool = AtomicBool::new(false);
-    if !INVALID.load(SeqCst) {
-        let times = [super::to_timespec(&atime), super::to_timespec(&mtime)];
-
-        // We normally use a syscall because the `utimensat` function is documented
-        // as not accepting a file descriptor in the first argument (even though, on
-        // Linux, the syscall itself can accept a file descriptor there).
-        #[cfg(not(target_env = "musl"))]
-        let rc = unsafe {
-            libc::syscall(
-                libc::SYS_utimensat,
-                f.as_raw_fd(),
-                ptr::null::<libc::c_char>(),
-                times.as_ptr(),
-                0,
-            )
-        };
-        // However, on musl, we call the musl libc function instead. This is because
-        // on newer musl versions starting with musl 1.2, `timespec` is always a 64-bit
-        // value even on 32-bit targets. As a result, musl internally converts their
-        // `timespec` values to the correct ABI before invoking the syscall. Since we
-        // use `timespec` from the libc crate, it matches musl's definition and not
-        // the Linux kernel's version (for some platforms) so we must use musl's
-        // `utimensat` function to properly convert the value. musl's `utimensat`
-        // function allows file descriptors in the path argument so this is fine.
-        #[cfg(target_env = "musl")]
-        let rc = unsafe {
-            libc::utimensat(
-                f.as_raw_fd(),
-                ptr::null::<libc::c_char>(),
-                times.as_ptr(),
-                0,
-            )
-        };
-
-        if rc == 0 {
-            return Ok(());
-        }
-        let err = io::Error::last_os_error();
-        if err.raw_os_error() == Some(libc::ENOSYS) {
-            INVALID.store(true, SeqCst);
-        } else {
-            return Err(err);
-        }
-    }
-
-    super::utimes::set_file_handle_times(f, atime, mtime)
-}
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
     set_times(p, Some(atime), Some(mtime), true)

--- a/src/unix/macos.rs
+++ b/src/unix/macos.rs
@@ -1,46 +1,14 @@
 //! Beginning with macOS 10.13, `utimensat` is supported by the OS, so here, we check if the symbol exists
 //! and if not, we fallback to `utimes`.
+
 use crate::FileTime;
 use libc::{c_char, c_int, timespec};
 use std::ffi::{CStr, CString};
-use std::fs::File;
 use std::os::unix::prelude::*;
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::{io, mem};
-
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), Some(mtime), false)
-}
-
-pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
-    set_times(p, None, Some(mtime), false)
-}
-
-pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), None, false)
-}
-
-pub fn set_file_handle_times(
-    f: &File,
-    atime: Option<FileTime>,
-    mtime: Option<FileTime>,
-) -> io::Result<()> {
-    // Attempt to use the `futimens` syscall, but if it's not supported by the
-    // current kernel then fall back to an older syscall.
-    if let Some(func) = futimens() {
-        let times = [super::to_timespec(&atime), super::to_timespec(&mtime)];
-        let rc = unsafe { func(f.as_raw_fd(), times.as_ptr()) };
-        if rc == 0 {
-            return Ok(());
-        } else {
-            return Err(io::Error::last_os_error());
-        }
-    }
-
-    super::utimes::set_file_handle_times(f, atime, mtime)
-}
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
     set_times(p, Some(atime), Some(mtime), true)
@@ -79,14 +47,6 @@ fn utimensat() -> Option<unsafe extern "C" fn(c_int, *const c_char, *const times
     static ADDR: AtomicUsize = AtomicUsize::new(0);
     unsafe {
         fetch(&ADDR, CStr::from_bytes_with_nul_unchecked(b"utimensat\0"))
-            .map(|sym| mem::transmute(sym))
-    }
-}
-
-fn futimens() -> Option<unsafe extern "C" fn(c_int, *const timespec) -> c_int> {
-    static ADDR: AtomicUsize = AtomicUsize::new(0);
-    unsafe {
-        fetch(&ADDR, CStr::from_bytes_with_nul_unchecked(b"futimens\0"))
             .map(|sym| mem::transmute(sym))
     }
 }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1,7 +1,9 @@
 use crate::FileTime;
 use libc::{time_t, timespec, UTIME_OMIT};
 use std::fs;
+use std::io;
 use std::os::unix::prelude::*;
+use std::path::Path;
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {
@@ -60,17 +62,9 @@ pub fn from_last_access_time(meta: &fs::Metadata) -> FileTime {
 }
 
 pub fn from_creation_time(meta: &fs::Metadata) -> Option<FileTime> {
-    #[cfg(target_os = "bitrig")]
-    {
-        use std::os::bitrig::fs::MetadataExt;
-        Some(FileTime {
-            seconds: meta.st_birthtime(),
-            nanos: meta.st_birthtime_nsec() as u32,
-        })
-    }
+    meta.created().map(|i| i.into()).ok()
+}
 
-    #[cfg(not(target_os = "bitrig"))]
-    {
-        meta.created().map(|i| i.into()).ok()
-    }
+pub fn open(path: &Path) -> io::Result<fs::File> {
+    fs::File::open(path)
 }

--- a/src/unix/utimensat.rs
+++ b/src/unix/utimensat.rs
@@ -1,35 +1,8 @@
 use crate::FileTime;
 use std::ffi::CString;
-use std::fs::File;
 use std::io;
 use std::os::unix::prelude::*;
 use std::path::Path;
-
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), Some(mtime), false)
-}
-
-pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
-    set_times(p, None, Some(mtime), false)
-}
-
-pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), None, false)
-}
-
-pub fn set_file_handle_times(
-    f: &File,
-    atime: Option<FileTime>,
-    mtime: Option<FileTime>,
-) -> io::Result<()> {
-    let times = [super::to_timespec(&atime), super::to_timespec(&mtime)];
-    let rc = unsafe { libc::futimens(f.as_raw_fd(), times.as_ptr()) };
-    if rc == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
     set_times(p, Some(atime), Some(mtime), true)

--- a/src/unix/utimes.rs
+++ b/src/unix/utimes.rs
@@ -5,61 +5,6 @@ use std::io;
 use std::os::unix::prelude::*;
 use std::path::Path;
 
-#[allow(dead_code)]
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), Some(mtime), false)
-}
-
-#[allow(dead_code)]
-pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
-    set_times(p, None, Some(mtime), false)
-}
-
-#[allow(dead_code)]
-pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
-    set_times(p, Some(atime), None, false)
-}
-
-#[cfg(not(target_env = "uclibc"))]
-#[allow(dead_code)]
-pub fn set_file_handle_times(
-    f: &fs::File,
-    atime: Option<FileTime>,
-    mtime: Option<FileTime>,
-) -> io::Result<()> {
-    let (atime, mtime) = match get_times(atime, mtime, || f.metadata())? {
-        Some(pair) => pair,
-        None => return Ok(()),
-    };
-    let times = [to_timeval(&atime), to_timeval(&mtime)];
-    let rc = unsafe { libc::futimes(f.as_raw_fd(), times.as_ptr()) };
-    return if rc == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    };
-}
-
-#[cfg(target_env = "uclibc")]
-#[allow(dead_code)]
-pub fn set_file_handle_times(
-    f: &fs::File,
-    atime: Option<FileTime>,
-    mtime: Option<FileTime>,
-) -> io::Result<()> {
-    let (atime, mtime) = match get_times(atime, mtime, || f.metadata())? {
-        Some(pair) => pair,
-        None => return Ok(()),
-    };
-    let times = [to_timespec(&atime), to_timespec(&mtime)];
-    let rc = unsafe { libc::futimens(f.as_raw_fd(), times.as_ptr()) };
-    return if rc == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    };
-}
-
 fn get_times(
     atime: Option<FileTime>,
     mtime: Option<FileTime>,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,21 +1,9 @@
 use crate::FileTime;
-use std::fs::{self, File};
+use std::fs;
 use std::io;
 use std::path::Path;
 
-pub fn set_file_times(_p: &Path, _atime: FileTime, _mtime: FileTime) -> io::Result<()> {
-    Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
-}
-
 pub fn set_symlink_file_times(_p: &Path, _atime: FileTime, _mtime: FileTime) -> io::Result<()> {
-    Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
-}
-
-pub fn set_file_mtime(_p: &Path, _mtime: FileTime) -> io::Result<()> {
-    Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
-}
-
-pub fn set_file_atime(_p: &Path, _atime: FileTime) -> io::Result<()> {
     Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
 }
 
@@ -31,10 +19,6 @@ pub fn from_creation_time(_meta: &fs::Metadata) -> Option<FileTime> {
     unimplemented!()
 }
 
-pub fn set_file_handle_times(
-    _f: &File,
-    _atime: Option<FileTime>,
-    _mtime: Option<FileTime>,
-) -> io::Result<()> {
-    Err(io::Error::new(io::ErrorKind::Other, "Wasm not implemented"))
+pub fn open(path: &Path) -> io::Result<fs::File> {
+    fs::File::open(path)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,99 +1,26 @@
 use crate::FileTime;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io;
+use std::os::windows::fs::OpenOptionsExt;
 use std::os::windows::prelude::*;
 use std::path::Path;
-use std::ptr;
 
-#[repr(C)]
-#[allow(non_snake_case)]
-struct FILETIME {
-    pub dwLowDateTime: u32,
-    pub dwHighDateTime: u32,
-}
-
-type HANDLE = *mut core::ffi::c_void;
-type BOOL = i32;
 const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x2000000;
 const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x200000;
 
-extern "system" {
-    fn SetFileTime(
-        hfile: HANDLE,
-        lpcreationtime: *const FILETIME,
-        lplastaccesstime: *const FILETIME,
-        lplastwritetime: *const FILETIME,
-    ) -> BOOL;
-}
-
-pub fn set_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    let f = OpenOptions::new()
+pub fn open(p: &Path) -> io::Result<fs::File> {
+    OpenOptions::new()
         .write(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(p)?;
-    set_file_handle_times(&f, Some(atime), Some(mtime))
-}
-
-pub fn set_file_mtime(p: &Path, mtime: FileTime) -> io::Result<()> {
-    let f = OpenOptions::new()
-        .write(true)
-        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(p)?;
-    set_file_handle_times(&f, None, Some(mtime))
-}
-
-pub fn set_file_atime(p: &Path, atime: FileTime) -> io::Result<()> {
-    let f = OpenOptions::new()
-        .write(true)
-        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(p)?;
-    set_file_handle_times(&f, Some(atime), None)
-}
-
-pub fn set_file_handle_times(
-    f: &File,
-    atime: Option<FileTime>,
-    mtime: Option<FileTime>,
-) -> io::Result<()> {
-    let atime = atime.map(to_filetime);
-    let mtime = mtime.map(to_filetime);
-    return unsafe {
-        let ret = SetFileTime(
-            f.as_raw_handle() as HANDLE,
-            ptr::null(),
-            atime
-                .as_ref()
-                .map(|p| p as *const FILETIME)
-                .unwrap_or(ptr::null()),
-            mtime
-                .as_ref()
-                .map(|p| p as *const FILETIME)
-                .unwrap_or(ptr::null()),
-        );
-        if ret != 0 {
-            Ok(())
-        } else {
-            Err(io::Error::last_os_error())
-        }
-    };
-
-    fn to_filetime(ft: FileTime) -> FILETIME {
-        let intervals = ft.seconds() * (1_000_000_000 / 100) + ((ft.nanoseconds() as i64) / 100);
-        FILETIME {
-            dwLowDateTime: intervals as u32,
-            dwHighDateTime: (intervals >> 32) as u32,
-        }
-    }
+        .open(p)
 }
 
 pub fn set_symlink_file_times(p: &Path, atime: FileTime, mtime: FileTime) -> io::Result<()> {
-    use std::os::windows::fs::OpenOptionsExt;
-
     let f = OpenOptions::new()
         .write(true)
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)
         .open(p)?;
-    set_file_handle_times(&f, Some(atime), Some(mtime))
+    crate::set_file_handle_times(&f, Some(atime), Some(mtime))
 }
 
 pub fn from_last_modification_time(meta: &fs::Metadata) -> FileTime {


### PR DESCRIPTION
Only `set_symlink_file_times` remains, and in theory that'll stabilize soon as well...